### PR TITLE
Correct payload for compute instance insert request.

### DIFF
--- a/google-cloud-compute.html
+++ b/google-cloud-compute.html
@@ -466,7 +466,6 @@ without specifying any attributes.
         }
         var payload = {
           project: this.config.project,
-          name: this.name,
           zone: this.zone,
           resource: {
             name: this.name,


### PR DESCRIPTION
Having a top-level `name` property makes JS GAPI client generate incorrect payload for `instance insert` request.

This PR removes top-level `name` property. It is already present in the resource object.
